### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/maiis/quickynab/security/code-scanning/7](https://github.com/maiis/quickynab/security/code-scanning/7)

To fix the problem, add a `permissions` block with the least privilege required at either the workflow or job level. Since the workflow shown only checks out code and installs/tests/builds dependencies (no obvious use of push, PR, or release actions), the minimal permission of `contents: read` is sufficient and recommended. This block can be placed at the workflow root (applies to all jobs) or just before/inside the job definition (applies to that job only). Here, the most robust fix for all future jobs is to add it at the workflow root—directly under the `name:` line and before the `on:` block.

No external libraries, dependencies, or further code changes are required; the only required change is the addition of the `permissions` key in the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
