### PR TITLE
Potential fix for code scanning alert no. 6: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/lib/uploader.ts
+++ b/lib/uploader.ts
@@ -85,7 +85,7 @@ function convertToMilliunits(amount: number): number {
  */
 function generateImportId(transaction: Transaction, accountId: string): string {
   const str = `${accountId}:${transaction.date}:${transaction.amount}:${transaction.payee_name || ''}`;
-  const hash = crypto.createHash('md5').update(str).digest('hex');
+  const hash = crypto.createHash('sha256').update(str).digest('hex');
   // Return first 32 chars of hash (36 char limit, just use hash)
   return hash.substring(0, 32);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/maiis/quickynab/security/code-scanning/6](https://github.com/maiis/quickynab/security/code-scanning/6)

The best way to fix the problem is to replace the use of the weak MD5 hash function with a strong hash function from the SHA-2 family, such as SHA-256, using the same crypto API. Specifically, in lib/uploader.ts, the function `generateImportId` should use `crypto.createHash('sha256')` instead of `crypto.createHash('md5')`. Since the maximum length for import_id is 36 characters and the code currently generates a 32 character hex digest, using SHA-256 will result in a 64 character hex string, so we will keep only the first 32 characters for compatibility (unless YNAB’s API requires something different). This maintains all existing logic and functionality.

Only line 88 of lib/uploader.ts needs to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
