### PR TITLE
Potential fix for code scanning alert no. 9: Missing rate limiting

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -151,11 +151,9 @@ fastify.get('/api/health', async () => {
 fastify.get(
   '/api/config',
   {
-    config: {
-      rateLimit: {
-        max: 10, // maximum 10 requests
-        timeWindow: '1 minute', // per minute
-      },
+    rateLimit: {
+      max: 10, // maximum 10 requests
+      timeWindow: '1 minute', // per minute
     },
   },
   async () => {


### PR DESCRIPTION
Potential fix for [https://github.com/maiis/quickynab/security/code-scanning/9](https://github.com/maiis/quickynab/security/code-scanning/9)

To fix the problem, the `/api/config` route needs to apply rate limiting using the Fastify rate limiting middleware (`@fastify/rate-limit`), and the options must be set up where Fastify expects them. The rate limiter for a route should be specified as a top-level `rateLimit` property in the route options object (not nested under `config`). The fix requires moving the current rate limiting options out of the `config` object and into the correct place. No other changes or imports are required since the rate-limiting plugin is already imported and likely registered globally.

**Steps:**
- In `server.ts`, move the `rateLimit` block from under `config:` to be a top-level property in the options argument to `fastify.get` for `/api/config` (lines 153–160).
- This applies the route-specific rate limiting as intended.
- No additional code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
