### PR TITLE
Potential fix for code scanning alert no. 5: CORS misconfiguration for credentials transfer

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -83,9 +83,16 @@ fastify.addHook('onRequest', async (request, reply) => {
   const origin = request.headers.origin;
 
   if (origin) {
-    const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:3000'];
+    // Parse and sanitize allowed origins, excluding "null" and trimming whitespace
+    const allowedOrigins = (process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:3000'])
+      .map(o => o.trim())
+      .filter(o => o !== 'null' && o.length > 0);
 
-    if (process.env.NODE_ENV === 'development' || allowedOrigins.includes(origin)) {
+    // Only allow CORS headers when in development OR if the provided origin exactly matches a safe, whitelisted origin
+    if (
+      process.env.NODE_ENV === 'development' ||
+      allowedOrigins.some(allowed => allowed === origin)
+    ) {
       reply.header('Access-Control-Allow-Origin', origin);
       reply.header('Access-Control-Allow-Credentials', 'true');
       reply.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');


### PR DESCRIPTION
Potential fix for [https://github.com/maiis/quickynab/security/code-scanning/5](https://github.com/maiis/quickynab/security/code-scanning/5)

To securely set `Access-Control-Allow-Origin` when allowing credentials:

- Do not reflect the incoming `origin` header value unless it is explicitly whitelisted.
- Ensure that the whitelist contains only safe and trusted origins, and does not include `"null"` (since it can be spoofed easily by attackers).
- Use strict equality to avoid partial matches (e.g., avoid `.includes()` over substring matches).
- Explicitly exclude `"null"` from the whitelist, and do not allow it to be set as `Access-Control-Allow-Origin` if credentials are allowed.
- Update the code in the `onRequest` hook (lines 82–95) in `server.ts` so that:
  - The incoming `origin` is compared (with equality) to a sanitized list of allowed origins.
  - `"null"` is excluded, even if present in the environment variable.
  - Only if `origin` matches a safe, explicit whitelist entry do we set CORS headers allowing credentials.

No additional packages are required for this change.  
The required edit is within lines 82–95 in `server.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
