### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -15,6 +15,9 @@ import { listAccounts, listBudgets, uploadTransactions } from './lib/uploader.js
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Register rate limiting plugin
+fastify.register(rateLimit);
+
 // Validate environment variables
 const env = envSchema.parse(process.env);
 


### PR DESCRIPTION
Potential fix for [https://github.com/maiis/quickynab/security/code-scanning/4](https://github.com/maiis/quickynab/security/code-scanning/4)

To properly protect the expensive `/api/upload` route, the Fastify rate limiting plugin (`@fastify/rate-limit`) must be registered with the Fastify instance using `fastify.register(rateLimit, opts)`. Once registered, global or per-route rate limits (like the one provided in the route config) will be respected. The best minimal fix is to register the plugin near the server initialization code (after creating `fastify`, before routes). No major rework is required: just insert a line like `fastify.register(rateLimit)` at an appropriate point after the call to `Fastify()` and before defining the route handlers. No further configuration is strictly needed, since the route-specific limit is already set. If desired, you may provide a default/global config, but this is not required for minimum compliance.  

Edit the file `server.ts`:
- Add `fastify.register(rateLimit);` after `const fastify = Fastify();` (after line 10, or after line 17 for env validation).
- No new imports are required, as the import (`import rateLimit from '@fastify/rate-limit';`) already exists.
- No other changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
