### PR TITLE
Potential fix for code scanning alert no. 5: CORS misconfiguration for credentials transfer

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -82,17 +82,14 @@ await fastify.register(fastifyMultipart, {
 fastify.addHook('onRequest', async (request, reply) => {
   const origin = request.headers.origin;
 
-  if (origin) {
+  if (origin && origin !== 'null') {
     // Parse and sanitize allowed origins, excluding "null" and trimming whitespace
     const allowedOrigins = (process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:3000'])
       .map((o) => o.trim())
       .filter((o) => o !== 'null' && o.length > 0);
 
-    // Only allow CORS headers when in development OR if the provided origin exactly matches a safe, whitelisted origin
-    if (
-      process.env.NODE_ENV === 'development' ||
-      allowedOrigins.some((allowed) => allowed === origin)
-    ) {
+    // Only allow CORS headers if the provided origin exactly matches a safe, whitelisted origin
+    if (allowedOrigins.includes(origin)) {
       reply.header('Access-Control-Allow-Origin', origin);
       reply.header('Access-Control-Allow-Credentials', 'true');
       reply.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');


### PR DESCRIPTION
Potential fix for [https://github.com/maiis/quickynab/security/code-scanning/5](https://github.com/maiis/quickynab/security/code-scanning/5)

To fully remediate this vulnerability, never echo back the `origin` value if it is `'null'` or falsy, and only *ever* accept origins present in the safe whitelist, even in development mode. Refuse to send any CORS headers for origins not in the whitelist, and most crucially, do not allow `'null'` to ever be in the whitelist. Also, adjust the code to avoid the special case for development mode that disables safety checks.

**Method:**
- Remove the condition for development mode to allow arbitrary origins.
- Always restrict CORS to the explicit whitelist.
- Explicitly check and refuse `'null'` and empty origins.
- Make sure `Access-Control-Allow-Origin` is set *only* for trusted, whitelisted origins.

Only lines inside the CORS `onRequest` hook (lines 81-102) need to change in `server.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
